### PR TITLE
Use env var to overload default approvals, pattern and team name

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -20,6 +20,7 @@ var (
 	approvals = envflag.Int("LGTM_APPROVALS", 2, "")
 	pattern = envflag.String("LGTM_PATTERN", "(?i)LGTM", "")
 	team = envflag.String("LGTM_TEAM", "MAINTAINERS", "")
+	selfApprovalOff = envflag.Bool("LGTM_SELF_APPROVAL_OFF", false, "")
 )
 
 // ParseConfig parses a projects .lgtm file
@@ -42,6 +43,9 @@ func ParseConfigStr(data string) (*Config, error) {
 	}
 	if len(c.Team) == 0 {
 		c.Team = *team
+	}
+	if c.SelfApprovalOff == false {
+		c.SelfApprovalOff = *selfApprovalOff
 	}
 
 	c.re, err = regexp.Compile(c.Pattern)

--- a/model/config.go
+++ b/model/config.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 
 	"github.com/BurntSushi/toml"
+	"github.com/ianschenck/envflag"
 )
 
 type Config struct {
@@ -14,6 +15,12 @@ type Config struct {
 
 	re *regexp.Regexp
 }
+
+var (
+	approvals = envflag.Int("LGTM_APPROVALS", 2, "")
+	pattern = envflag.String("LGTM_PATTERN", "(?i)LGTM", "")
+	team = envflag.String("LGTM_TEAM", "MAINTAINERS", "")
+)
 
 // ParseConfig parses a projects .lgtm file
 func ParseConfig(data []byte) (*Config, error) {
@@ -28,14 +35,15 @@ func ParseConfigStr(data string) (*Config, error) {
 		return nil, err
 	}
 	if c.Approvals == 0 {
-		c.Approvals = 2
+		c.Approvals = *approvals
 	}
 	if len(c.Pattern) == 0 {
-		c.Pattern = "(?i)LGTM"
+		c.Pattern = *pattern
 	}
 	if len(c.Team) == 0 {
-		c.Team = "MAINTAINERS"
+		c.Team = *team
 	}
+
 	c.re, err = regexp.Compile(c.Pattern)
 	return c, err
 }


### PR DESCRIPTION
LGTM_APPROVALS for the number of approvals (default `2`)
LGTM_PATTERN for the pattern (default `"(?i)LGTM"`)
LGTM_TEAM for the team name (default `MAINTAINERS`)
LGTM_SELF_APPROVAL_OFF for setting self approval off (default `false`)
