### PR TITLE
Remove static linking from build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ gen_migration:
 	go generate github.com/lgtmco/lgtm/store/migration
 
 build:
-	# do not staticly link sqlite. Doesn't work on OS X and breaks DNS resolution on linux
+	@# do not staticly link sqlite. Doesn't work on OS X and breaks DNS resolution on linux
 	go build --ldflags '-X github.com/lgtmco/lgtm/version.VersionDev=$(CI_BUILD_NUMBER)' -o lgtm
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ gen_migration:
 	go generate github.com/lgtmco/lgtm/store/migration
 
 build:
-	go build --ldflags '-extldflags "-static" -X github.com/lgtmco/lgtm/version.VersionDev=$(CI_BUILD_NUMBER)' -o lgtm
+	# do not staticly link sqlite. Doesn't work on OS X and breaks DNS resolution on linux
+	go build --ldflags '-X github.com/lgtmco/lgtm/version.VersionDev=$(CI_BUILD_NUMBER)' -o lgtm
 
 test:
 	@for PKG in $(PACKAGES); do go test -v -cover -coverprofile $$GOPATH/src/$$PKG/coverage.out $$PKG; done;


### PR DESCRIPTION
It doesn't work on Mac OS X and breaks dns resolution on Linux.

Breaking up the changes from @jonbodner branch so they are easier to review.
